### PR TITLE
vscode拡張のインストール設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM mcr.microsoft.com/devcontainers/go:1.20-bookworm
+FROM golang:1.22.4-bookworm AS env-builder
+
+RUN go install github.com/posener/complete/gocomplete@latest \
+    && go install golang.org/x/tools/gopls@v0.16.1 \
+    && go install github.com/cweill/gotests/gotests@v1.6.0 \
+    && go install github.com/go-delve/delve/cmd/dlv@v1.22.1
+
+FROM mcr.microsoft.com/devcontainers/go:1.20-bookworm as atcoder
 
 ARG USERNAME=vscode
 
@@ -11,11 +18,14 @@ RUN apt-get update \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/ \
     && ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
+COPY --from=env-builder /go/bin /go/bin
+
 COPY --chown=${USERNAME}:${USERNAME} ./resources/update-atgo /usr/local/bin/update-atgo
 RUN chmod +x /usr/local/bin/update-atgo
 
 USER ${USERNAME}
 
+RUN gocomplete -install -y
 RUN update-atgo
 
 RUN ll > /dev/null || echo 'alias ll="ls -alF"' >> "$HOME/.bashrc"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,12 @@ RUN chmod +x /usr/local/bin/update-atgo
 
 USER ${USERNAME}
 
-RUN gocomplete -install -y
-RUN update-atgo
+RUN mkdir -p /home/${USERNAME}/.local/bin
+COPY --chown=${USERNAME}:${USERNAME} ./resources/add-vsc-extension /home/${USERNAME}/.local/bin/add-vsc-extension
+RUN chmod +x /home/${USERNAME}/.local/bin/add-vsc-extension
+COPY --chown=${USERNAME}:${USERNAME} ./resources/vsc-extensions.list /home/${USERNAME}/.local/bin/vsc-extensions.list
 
-RUN ll > /dev/null || echo 'alias ll="ls -alF"' >> "$HOME/.bashrc"
+RUN gocomplete -install -y \
+    && update-atgo \
+    && ll > /dev/null || echo 'alias ll="ls -alF"' >> "$HOME/.bashrc" \
+    && echo 'source add-vsc-extension --complete' >> "$HOME/.bashrc"

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -15,5 +15,13 @@
 	],
 	"workspaceMount": "source=${localWorkspaceFolder},target=/atcoder,type=bind,consistency=cached",
 	"workspaceFolder": "/atcoder",
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go",
+				"MS-CEINTL.vscode-language-pack-ja"
+			]
+		}
+	}
 }

--- a/resources/add-vsc-extension
+++ b/resources/add-vsc-extension
@@ -1,0 +1,67 @@
+#!/bin/bash -e
+
+command -v code >/dev/null || {
+    echo "Visual Studio Code is not installed."
+    exit 1
+}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")"; pwd)
+DATAFILE="$SCRIPT_DIR/vsc-extensions.list"
+
+if [ "$1" == "--help" ]; then
+    cat <<HELP
+Usage:
+    add-vsc-extension [extension-id]
+        extension-id: vscode extension id to install
+
+If extension-id is not specified, list all extensions in $DATAFILE.
+HELP
+    exit 0
+fi
+
+if [ "$1" == "--complete" ]; then
+    cscript=$(cat << 'SCRIPT'
+_vsc_ext_completions() {
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    COMPREPLY=()
+
+    local datafile='#DATAFILE#'
+    [ -f "$datafile" ] || return
+
+    local installed=$(code --list-extensions)
+    local extensions=()
+    mapfile -t extensions < "$datafile"
+
+    local candidates=()
+    for ext in "${extensions[@]}"; do
+        if [[ ! " $(echo ${installed[@]}) " =~ " $ext " ]]; then
+            candidates+=("$ext")
+        fi
+    done
+
+    COMPREPLY=( $(compgen -W "${candidates[*]}" -- "$cur") )
+}
+SCRIPT
+)
+
+    eval "$(echo "$cscript" | sed -e "s|#DATAFILE#|$DATAFILE|")"
+    complete -F _vsc_ext_completions add-vsc-extension
+
+    return
+fi
+
+ext="$1"
+
+if [ -n "$ext" ]; then
+    code --install-extension "$ext"
+else
+    echo "all extensions list:"
+    installed="$(code --list-extensions)"
+    cat "$DATAFILE" | while read line; do
+        if [[ " $(echo ${installed[@]}) " =~ " $line " ]]; then
+            echo "(installed) $line"
+        else
+            echo "            $line"
+        fi
+    done
+fi

--- a/resources/vsc-extensions.list
+++ b/resources/vsc-extensions.list
@@ -1,0 +1,2 @@
+github.copilot
+windmilleng.vscode-go-autotest


### PR DESCRIPTION
デフォルトで追加するvscode拡張とオプションでインストール可能なvscode拡張を追加しました。

### デフォルトで追加する拡張

- golang.go
    - goplsなどの追加モジュールのインストールも対応
- MS-CEINTL.vscode-language-pack-ja

### インストーラー経由でインストール可能な拡張

- GitHub.copilot
- windmilleng.vscode-go-autotest

### その他

- gocomplete も合わせて対応した(goコマンドの引数補完)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 新しいDockerfile構成を導入し、ツールのインストールとユーザー固有の設定を追加しました。
  - `devcontainer.json`にVS Code拡張機能のカスタマイズを追加しました（`golang.go`および`MS-CEINTL.vscode-language-pack-ja`）。
  - 新しいbashスクリプト`add-vsc-extension`を追加し、VS Code拡張機能の管理をサポートしました。
  - Visual Studio Code拡張機能リストファイル`vsc-extensions.list`を追加しました（`github.copilot`および`windmilleng.vscode-go-autotest`）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->