### PR TITLE
ベースイメージをdevcontainer => DockerHubのコンテナに変更

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -8,6 +8,10 @@
 			"USERNAME": "vscode"
 		}
 	},
+	"runArgs": [
+		"--hostname",
+		"devcontainer-atgo-go"
+	],
 	"mounts": [
 		"source=go-cache-volume,target=/home/vscode/.cache/go-build,type=volume",
 		"source=go-pkg-volume,target=/go/pkg,type=volume"

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -8,7 +8,6 @@
 			"USERNAME": "vscode"
 		}
 	},
-	"postCreateCommand": "./.devcontainer/postCommand.sh vscode && atgo version --long",
 	"mounts": [
 		"source=go-cache-volume,target=/home/vscode/.cache/go-build,type=volume",
 		"source=go-pkg-volume,target=/go/pkg,type=volume"
@@ -16,6 +15,7 @@
 	"workspaceMount": "source=${localWorkspaceFolder},target=/atcoder,type=bind,consistency=cached",
 	"workspaceFolder": "/atcoder",
 	"remoteUser": "vscode",
+	"postCreateCommand": "./.devcontainer/postCommand.sh vscode && atgo version --long",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -19,7 +19,7 @@
 	"workspaceMount": "source=${localWorkspaceFolder},target=/atcoder,type=bind,consistency=cached",
 	"workspaceFolder": "/atcoder",
 	"remoteUser": "vscode",
-	"postCreateCommand": "./.devcontainer/postCommand.sh vscode && atgo version --long",
+	"postCreateCommand": "./.devcontainer/postCommand.sh vscode",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/postCommand.sh
+++ b/postCommand.sh
@@ -7,10 +7,13 @@ sudo chown vscode:golang /go/pkg
 sudo mkdir -p "/home/$u/.cache/go-build"
 sudo chown vscode:vscode "/home/$u/.cache/go-build"
 
-mkdir -p /etc/bash_completion.d
-atgo completion bash | sudo tee /etc/bash_completion.d/atgo | cat > /dev/null
+source ~/.profile
+
+atgo completion bash | sudo tee /etc/bash_completion.d/atgo > /dev/null
 
 LSCRIPT="$(cd "$(dirname "$0")"; pwd)/postCommand.local.sh"
 if [ -x "$LSCRIPT" ]; then
     "$LSCRIPT" "$u"
 fi
+
+atgo version --long


### PR DESCRIPTION
Goのバージョンを1.20.6に固定化するため、コンテナのベースイメージをDockerHubのものに差し替えました。

その他改善を含んでいます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - bash補完機能のセットアップを追加しました。
  - 新しいユーザーの作成とsudoアクセスの設定を追加しました。

- **改善**
  - Dockerfileのベースイメージを`golang:1.20.6-bookworm`に変更しました。
  - `devcontainer.json`にホスト名設定のための引数を追加しました。

- **削除**
  - `devcontainer.json`からバージョンチェックに関連するコマンドを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->