### PR TITLE
権限の調整周り

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,12 @@ RUN useradd -m -g $USERNAME -u 1000 -s /bin/bash -G golang $USERNAME \
     && chown -R $USERNAME:golang /go \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME
 
-COPY --from=env-builder /go/bin /go/bin
-
 COPY --chown=${USERNAME}:${USERNAME} ./resources/update-atgo /usr/local/bin/update-atgo
 RUN chmod +x /usr/local/bin/update-atgo
 
 USER ${USERNAME}
+
+COPY --from=env-builder --chown=$USERNAME:golang /go/bin /go/bin
 
 RUN mkdir -p /home/${USERNAME}/.local/bin
 COPY --chown=${USERNAME}:${USERNAME} ./resources/add-vsc-extension /home/${USERNAME}/.local/bin/add-vsc-extension

--- a/postCommand.sh
+++ b/postCommand.sh
@@ -13,7 +13,7 @@ atgo completion bash | sudo tee /etc/bash_completion.d/atgo > /dev/null
 
 LSCRIPT="$(cd "$(dirname "$0")"; pwd)/postCommand.local.sh"
 if [ -x "$LSCRIPT" ]; then
-    "$LSCRIPT" "$u"
+    "$LSCRIPT" "$user"
 fi
 
 atgo version --long

--- a/postCommand.sh
+++ b/postCommand.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-u=$1
+user=$1
 
 sudo mkdir -p /go/pkg
-sudo chown vscode:golang /go/pkg
-sudo mkdir -p "/home/$u/.cache/go-build"
-sudo chown vscode:vscode "/home/$u/.cache/go-build"
+sudo chown -R "$user:golang" /go/pkg
+sudo mkdir -p "/home/$user/.cache/go-build"
+sudo chown "$user:$user" "/home/$user/.cache/go-build"
 
 source ~/.profile
 


### PR DESCRIPTION
- 別ボリュームをマウントしているディレクトリの権限設定を引数のユーザー名を引き回すように変更した
- `/go/bin` 配下のファイルは後に更新することがあるため、ユーザーをオーナーに変更した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更点**
  - Dockerfileの`COPY`コマンドに`--chown`ディレクティブを追加し、ファイルコピー時の所有者を設定するように変更しました。
  - `postCommand.sh`スクリプトでユーザー識別とディレクトリ所有権の処理を改善し、正しいパーミッションを確保しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->