### PR TITLE
ビルダーのバージョンをGo1.23.0に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.22.4-bookworm AS env-builder
+FROM golang:1.23.0-bookworm AS env-builder
 
 RUN go install github.com/posener/complete/gocomplete@latest \
     && go install golang.org/x/tools/gopls@v0.16.1 \
     && go install github.com/cweill/gotests/gotests@v1.6.0 \
-    && go install github.com/go-delve/delve/cmd/dlv@v1.22.1
+    && go install github.com/go-delve/delve/cmd/dlv@v1.23.0
 
 FROM golang:1.20.6-bookworm as atcoder
 


### PR DESCRIPTION
追加でgo拡張機能のモジュールのうちアップデートされたものを上げています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Goプログラミング環境のベースイメージを新しいバージョンに更新しました（`golang:1.23.0-bookworm`）。
	- Delveデバッガーのバージョンを更新し、デバッグ体験の向上を図りました（`v1.23.0`）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->